### PR TITLE
Label grid support

### DIFF
--- a/spiffyplots/multipanel.py
+++ b/spiffyplots/multipanel.py
@@ -3,7 +3,7 @@
 """
 
 from collections import defaultdict
-from itertools import chain, product
+from itertools import product
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gs

--- a/spiffyplots/multipanel.py
+++ b/spiffyplots/multipanel.py
@@ -223,11 +223,11 @@ class MultiPanel(object):
         # # # # # # # # # # # #
 
         # Raise a warning if there are overlapping panels
-        if _panel_overlap(self._locations, self.shape):
+        overlaps = _panel_overlap(self._locations, self.shape)
+        if len(overlaps) != 0 :
             warnings.warn(
-                "One or more panels overlap! This will not impact functionality, but"
-                "might lead to visually unappealing figures."
-                "Please check your input parameters if this was not intentionally."
+                "One or more panel coordinates overlap: {}! You probably do not "
+                "want this, double check your input coordinates."
             )
 
         # Initialize GridSpec and consider Keyword Arguments
@@ -482,7 +482,7 @@ def _panel_overlap(locations, shape=None):
     # examine all pairs of locations to make sure nothing overlaps
     overlap = False
     for loc1, loc2 in combinations(coords,2) :
-        overlap = len(set(loc1).intersection(loc2)) != 0
+        overlap = set(loc1).intersection(loc2)
         if overlap : break
 
     return overlap

--- a/spiffyplots/multipanel.py
+++ b/spiffyplots/multipanel.py
@@ -3,7 +3,7 @@
 """
 
 from collections import defaultdict
-from itertools import product
+from itertools import product, combinations
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gs
@@ -463,17 +463,26 @@ def _find_max_tuple(
     return max1 + 1, max2 + 1
 
 
-def _panel_overlap(locations, shape):
+def _panel_overlap(locations, shape=None):
+    """
+    Check a list of (x,y) location coordinates, which may be ranges, to ensure
+    none overlap
 
-    # make a testgrid of random numbers
-    testgrid = np.random.rand(*shape)
+    :param locations: list of (x,y) tuple locations
+    :param shape: the shape the locations should fit into (deprecated)
+    """
 
-    testvalues = []
-    for ix in locations:
-        testvalues.append(list(testgrid[ix].flatten()))
-    testvalues = [item for sublist in testvalues for item in sublist]
+    # expand all coordinates for each location
+    coords = []
+    for loc in locations:
+        xlocs = loc[0] if isinstance(loc[0],range) else [loc[0]]
+        ylocs = loc[1] if isinstance(loc[1],range) else [loc[1]]
+        coords.append(list(product(xlocs,ylocs)))
 
-    # check whether no panels overlap
-    overlap = len(testvalues) != len(set(testvalues))
+    # examine all pairs of locations to make sure nothing overlaps
+    overlap = False
+    for loc1, loc2 in combinations(coords,2) :
+        overlap = len(set(loc1).intersection(loc2)) != 0
+        if overlap : break
 
     return overlap

--- a/spiffyplots/multipanel.py
+++ b/spiffyplots/multipanel.py
@@ -300,7 +300,7 @@ def _get_letters(case: Optional[str] = "uppercase") -> str:
     else:
         return string.ascii_uppercase
 
-def _is_label_grid_spec(labels) -> bool:
+def _is_iter_of_iters(labels) -> bool:
     """
     Helper function to check for iterable of iterables
     """
@@ -317,7 +317,16 @@ def _decode_label_array(labels: Iterable[Iterable]) -> dict:
     :return: The mapping in dictionary form
     """
 
+
+
     # make sure we've got a list of lists
+    if not _is_iter_of_iters(labels) :
+        raise TypeError(
+                "Sorry, ``labels`` must be a iterable of iterables, where "
+                "each sub-iterable is the same length"
+            )
+
+
     label_grid = [list(_) for _ in labels]
 
     # verify labels format

--- a/spiffyplots/multipanel.py
+++ b/spiffyplots/multipanel.py
@@ -2,6 +2,8 @@
 """The Spiffy MultiPanel class and its methods.
 """
 
+from collections import defaultdict
+from itertools import chain, product
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gs
@@ -135,7 +137,7 @@ class MultiPanel(object):
         # the shape and grid parameters are ignored.
 
         # If labels is given as a numpy array, decode it into dictionary form.
-        if isinstance(labels, np.ndarray):
+        if isinstance(labels,np.ndarray):
             labels = _decode_label_array(labels)
 
         if isinstance(labels, dict):
@@ -298,16 +300,65 @@ def _get_letters(case: Optional[str] = "uppercase") -> str:
     else:
         return string.ascii_uppercase
 
+def _is_label_grid_spec(labels) -> bool:
+    """
+    Helper function to check for iterable of iterables
+    """
+    return isinstance(labels,Iterable) and all(isinstance(_,Iterable) for _ in labels)
 
-def _decode_label_array(labels: np.array) -> dict:
+def _decode_label_array(labels: Iterable[Iterable]) -> dict:
     """
     Helper function to transform a numpy array of subplot specifications into a dictionary
-    mapping labels to locations
-    :param labels: np.array that maps cells in in the grid to a subplot label
+    mapping labels to locations. Generally accepts iterables of iterables, including
+    numpy arrays, list of lists, and list of strings, where the latter assumes
+    labels are individual characters.
+
+    :param labels: grid of labels that maps cells in in the grid to a subplot label
     :return: The mapping in dictionary form
     """
-    NotImplemented
 
+    # make sure we've got a list of lists
+    label_grid = [list(_) for _ in labels]
+
+    # verify labels format
+    if not all(len(_) == len(label_grid[0]) for _ in label_grid[1:]) :
+        raise TypeError(
+                "Sorry, ``labels`` must be a iterable of iterables, where "
+                "each sub-iterable is the same length"
+            )
+
+    # collect grid positions for each label
+    label_pos = defaultdict(list)
+    for i,row in enumerate(label_grid) :
+        for j,label in enumerate(row) :
+            label_pos[label].append((i,j))
+
+    # ensure labels spanning grid points are linear contiguous
+    label_dict = {}
+    for label, positions in label_pos.items() :
+
+        rows = list(set([_[0] for _ in positions]))
+        cols = list(set([_[1] for _ in positions]))
+
+        row_range = range(min(rows),max(rows)+1)
+        col_range = range(min(cols),max(cols)+1)
+
+        # check that the label grid positions form a box
+        expected_coords = list(product(rows,cols))
+        if set(positions) != set(expected_coords) :
+            raise TypeError(
+                    "Sorry, label grid spec contains invalid layout; "
+                    "all identical label positions must be adjacent"
+                )
+
+        if len(rows) == 1 :
+            row_range = rows[0]
+        if len(cols) == 1 :
+            col_range = cols[0]
+
+        label_dict[label] = (row_range, col_range)
+
+    return label_dict
 
 def _get_grid_location(
     location: Tuple, gridspec: matplotlib.gridspec.GridSpec

--- a/tests/test_multipanel.py
+++ b/tests/test_multipanel.py
@@ -431,8 +431,8 @@ class Test_panel_overlap(unittest.TestCase):
             (1,range(0,10))
         ]))
         self.assertTrue(mp._panel_overlap([
-            (0,range(0,3)),
-            (0,range(1,4))
+            (0,range(0,2)),
+            (0,range(1,2))
         ]))
         self.assertFalse(mp._panel_overlap([
             (range(0,2),range(0,2)),

--- a/tests/test_multipanel.py
+++ b/tests/test_multipanel.py
@@ -224,6 +224,14 @@ class Test_get_letters(unittest.TestCase):
         self.assertEqual(out[2], "C")
         self.assertEqual(out[-1], "Z")
 
+class Test_is_iter_of_iters(unittest.TestCase) :
+    def test_default(self) :
+        """Test _is_iter_of_iters"""
+        self.assertTrue(mp._is_iter_of_iters([[1]]))
+        self.assertTrue(mp._is_iter_of_iters([[1],[2]]))
+        self.assertTrue(mp._is_iter_of_iters(['ABC','DEF']))
+        self.assertTrue(mp._is_iter_of_iters([]))
+        self.assertFalse(mp._is_iter_of_iters(1))
 
 class Test_decode_label_array(unittest.TestCase):
     def test_simple_array(self):

--- a/tests/test_multipanel.py
+++ b/tests/test_multipanel.py
@@ -276,6 +276,11 @@ class Test_decode_label_array(unittest.TestCase):
         ]))
         self.assertTrue(grid_dict['D'] == (1,range(0,3)))
 
+        # should raise on invalid input
+        self.assertRaises(TypeError, mp._decode_label_array,
+                1
+        )
+
     def test_complex_array(self):
         NotImplemented
 

--- a/tests/test_multipanel.py
+++ b/tests/test_multipanel.py
@@ -137,6 +137,13 @@ class TestMutiPanel(unittest.TestCase):
         fig = mp.MultiPanel(labels = labels)
         self.assertEqual(set(fig._locations),set([(0,range(0,2)),(1,range(0,2))]))
 
+        labels = np.array([
+            ['A', 'B','B'],
+            ['C', 'C','C'],
+            ['C', 'C','C']
+        ])
+        fig = mp.MultiPanel(labels = labels)
+
     def test_kwargs(self):
         """
         Test if different keyword arguments work as expected
@@ -252,6 +259,13 @@ class Test_decode_label_array(unittest.TestCase):
             ['B','C','C']
         ])
         self.assertTrue(grid_dict['C'] == (range(0,2),range(1,3)))
+
+        grid_dict = mp._decode_label_array([
+            ['A', 'B','B'],
+            ['C', 'C','C'],
+            ['C', 'C','C']
+        ])
+        self.assertTrue(grid_dict['C'] == (range(1,3),range(0,3)))
 
         # discontiguous labels
         self.assertRaises(TypeError, mp._decode_label_array,
@@ -385,3 +399,53 @@ class Test_find_max_tuple(unittest.TestCase):
     def test_long_mixed(self):
         out = mp._find_max_tuple(self.long_mixed)
         self.assertEqual(out, (11, 5))
+
+    def test_large_subplots(self):
+        grid_dict = mp._decode_label_array([
+            ['A', 'B','B'],
+            ['C', 'C','C'],
+            ['C', 'C','C']
+        ])
+        self.assertEqual(mp._find_max_tuple(grid_dict.values()),(3,3))
+
+class Test_panel_overlap(unittest.TestCase):
+    def test_default(self) :
+        self.assertFalse(mp._panel_overlap([]))
+        self.assertFalse(mp._panel_overlap([
+            (0,0)
+        ]))
+        self.assertFalse(mp._panel_overlap([
+            (0,0),
+            (0,1)
+        ]))
+        self.assertFalse(mp._panel_overlap([
+            (0,0),(1,0),
+            (0,1),(1,1)
+        ]))
+        self.assertTrue(mp._panel_overlap([
+            (0,0),(1,0),
+            (0,1),(1,0)
+        ]))
+        self.assertFalse(mp._panel_overlap([
+            (0,range(0,10)),
+            (1,range(0,10))
+        ]))
+        self.assertTrue(mp._panel_overlap([
+            (0,range(0,3)),
+            (0,range(1,4))
+        ]))
+        self.assertFalse(mp._panel_overlap([
+            (range(0,2),range(0,2)),
+            (range(2,4),range(2,4))
+        ]))
+        self.assertTrue(mp._panel_overlap([
+            (range(0,2),range(0,2)),
+            (range(1,4),range(1,4))
+        ]))
+    def test_large_subplots(self):
+        grid_dict = mp._decode_label_array([
+            ['A', 'B','B'],
+            ['C', 'C','C'],
+            ['C', 'C','C']
+        ])
+        self.assertFalse(mp._panel_overlap(grid_dict.values(),(3,3)))

--- a/tests/test_multipanel.py
+++ b/tests/test_multipanel.py
@@ -1,5 +1,6 @@
 """Tests for `spiffyplots.multipanel` module."""
 
+from itertools import product
 
 import unittest
 import pytest
@@ -105,7 +106,7 @@ class TestMutiPanel(unittest.TestCase):
         """
         Test initialization of MultiPanel object.
 
-        004 - Initialization based on ``labels`` being a list of custom labels.
+        005 - Initialization based on ``labels`` being a list of custom labels.
         """
 
         labels = ['A1', 'A2',
@@ -113,6 +114,28 @@ class TestMutiPanel(unittest.TestCase):
         fig = mp.MultiPanel(labels = labels)
         self.assertEqual(fig.panels.__len__(), 4)
         self.assertEqual(fig._labels, labels)
+
+    def test_init_006_labels_array(self):
+        """
+        Test initialization of MultiPanel object.
+
+        004 - Initialization based on ``labels`` being a numpy array label grid
+        """
+
+        labels = np.array([
+            ['A1', 'A2'],
+            ['B1', 'B2']
+        ])
+        fig = mp.MultiPanel(labels = labels)
+        self.assertEqual(fig.panels.__len__(), 4)
+        self.assertEqual(set(fig._locations),set(product([0,1],[0,1])))
+
+        labels = np.array([
+            ['A', 'A'],
+            ['B', 'B']
+        ])
+        fig = mp.MultiPanel(labels = labels)
+        self.assertEqual(set(fig._locations),set([(0,range(0,2)),(1,range(0,2))]))
 
     def test_kwargs(self):
         """
@@ -204,7 +227,46 @@ class Test_get_letters(unittest.TestCase):
 
 class Test_decode_label_array(unittest.TestCase):
     def test_simple_array(self):
-        NotImplemented
+        grid_dict = mp._decode_label_array([
+            ['A','B','C'],
+            ['D','D','D']
+        ])
+        self.assertTrue(grid_dict['D'] == (1,range(0,3)))
+
+        grid_dict = mp._decode_label_array([
+            ['A','C','E'],
+            ['B','D','E']
+        ])
+        self.assertTrue(grid_dict['E'] == (range(0,2),2))
+
+        grid_dict = mp._decode_label_array([
+            ['A','C','C'],
+            ['B','C','C']
+        ])
+        self.assertTrue(grid_dict['C'] == (range(0,2),range(1,3)))
+
+        # discontiguous labels
+        self.assertRaises(TypeError, mp._decode_label_array,
+                [['A','B'],
+                 ['B','A']]
+        )
+        self.assertRaises(TypeError, mp._decode_label_array,
+                [['A','B','C'],
+                 ['C','B','A']]
+        )
+
+        # different types of iterable inputs
+        grid_dict = mp._decode_label_array([
+            'ABC',
+            'DDD'
+        ])
+        self.assertTrue(grid_dict['D'] == (1,range(0,3)))
+
+        grid_dict = mp._decode_label_array(np.array([
+            ['A','B','C'],
+            ['D','D','D']
+        ]))
+        self.assertTrue(grid_dict['D'] == (1,range(0,3)))
 
     def test_complex_array(self):
         NotImplemented


### PR DESCRIPTION
Hi,

I had actually written a class like this almost identical to yours a while back, but yours is further along and has a grander vision so I figured I'd contribute. I liked your idea of using a label grid spec but noticed it wasn't implemented. I implement and test the _decode_label_array function in this pull request. The function accepts any iterable of iterables, but the MultiPanel constructor only calls it when the input is a numpy array, as you describe in the docs.

Any suggestions welcome.